### PR TITLE
Switch to a `uv check`-based hook

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -4,7 +4,8 @@ Thank you for taking the time to report an issue! We're glad to have you involve
 If you're filing a bug report, please consider including the following information:
 
 * A minimal code snippet that reproduces the bug.
+* The current ty-pre-commit revision and hook configuration.
 * The current ty settings (any relevant sections from your `pyproject.toml`).
-* The current ty version (`ty --version`).
+* The output from `uv check`, if relevant.
 * A description of your environment (e.g., operating system, Python version, etc.).
 -->

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,7 +1,7 @@
 - id: ty
   name: ty
   description: "Run 'ty' for extremely fast Python type checking"
-  entry: ty check
+  entry: uv check --quiet --preview-features=check-command --ty-version=0.0.46
   language: python
   types: [python, pyi, jupyter]
   args: []

--- a/README.md
+++ b/README.md
@@ -1,19 +1,30 @@
 # ty-pre-commit
 
-[![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v2.json)](https://github.com/astral-sh/ty)
 [![image](https://img.shields.io/pypi/v/ty/0.0.46.svg)](https://pypi.python.org/pypi/ty)
 [![image](https://img.shields.io/pypi/l/ty/0.0.46.svg)](https://pypi.python.org/pypi/ty)
 [![image](https://img.shields.io/pypi/pyversions/ty/0.0.46.svg)](https://pypi.python.org/pypi/ty)
 [![Actions status](https://github.com/astral-sh/ty-pre-commit/workflows/main/badge.svg)](https://github.com/astral-sh/ty-pre-commit/actions)
 
-A [pre-commit](https://pre-commit.com/) hook for [ty](https://github.com/astral-sh/ty).
+A [pre-commit](https://pre-commit.com/) hook for running [ty](https://github.com/astral-sh/ty)
+quickly over your whole Python project.
 
-Distributed as a standalone repository to enable installing ty via prebuilt wheels from
-[PyPI](https://pypi.org/project/ty/).
+The hook uses the dependencies declared in your project's `pyproject.toml`, so your project
+configuration remains the single source of truth: you do not need to duplicate type-checking
+dependencies in the hook's `additional_dependencies` setting. By default, uv installs the project's [`dev`
+dependency group](https://docs.astral.sh/uv/concepts/projects/dependencies/#default-groups); use
+`tool.uv.default-groups` to customize which groups are installed.
+Any dependencies listed in the hook's `additional_dependencies` setting will be ignored by ty.
+
+Under the hood, the hook runs [uv](https://github.com/astral-sh/uv)'s preview
+[`uv check`](https://docs.astral.sh/uv/reference/cli/#uv-check) command. Each hook revision pins both
+the corresponding ty version and the latest uv version that was available when that ty version was
+released. New ty releases trigger ty-pre-commit releases; new uv releases do not trigger releases
+on their own. The full uv command invoked by the hook can be found in
+[`.pre-commit-hooks.yaml`](.pre-commit-hooks.yaml).
 
 ### Using ty with pre-commit
 
-To run ty's [type checker](https://docs.astral.sh/ty) via pre-commit, add the following to your `.pre-commit-config.yaml`:
+To run ty via pre-commit, add the following to your `.pre-commit-config.yaml`:
 
 ```yaml
 repos:
@@ -21,8 +32,59 @@ repos:
   # ty version.
   rev: v0.0.46
   hooks:
-    # Run the type checker.
     - id: ty
+```
+
+Configure ty in your project's `pyproject.toml` or `ty.toml`; see
+[ty's configuration reference](https://docs.astral.sh/ty/reference/configuration/).
+
+The `ty` hook uses uv's normal project behavior. It may create or update `uv.lock`, create a local
+virtual environment if one does not exist, and sync the local virtual environment before checking
+the project.
+
+The `ty` hook accepts additional [`uv check`](https://docs.astral.sh/uv/reference/cli/#uv-check)
+arguments. If you do not want the hook to create or update your project's lockfile or local virtual
+environment, use uv's isolated mode:
+
+```yaml
+hooks:
+  - id: ty
+    args: [--isolated]
+```
+
+`--isolated` resolves and installs the project's declared requirements into a temporary virtual
+environment. It leaves the project's existing virtual environment and lockfile unchanged, and does
+not create either one if it is missing. It may still populate uv's cache or download a compatible
+Python interpreter.
+
+Other synchronization options include:
+
+- `--locked` still syncs the virtual environment, but fails if `uv.lock` is missing or out of date.
+- `--frozen` still syncs the virtual environment using `uv.lock` without checking or updating it.
+- `--no-sync` skips synchronization entirely. Use it only if another step keeps the virtual
+  environment up to date.
+
+The hook always runs and does not pass filenames to ty. ty checks the full project according to your
+ty configuration, including for deletion-only commits where no Python filename remains for
+pre-commit or prek to match.
+
+You can customize which files ty emits diagnostics for using the [`src.include` and `src.exclude` settings](https://docs.astral.sh/ty/exclusions/) in your ty configuration.
+
+Do not set `pass_filenames: true`. `uv check` does not accept positional arguments, so the hook
+errors when pre-commit or prek appends filenames to the command.
+
+### Using ty with prek
+
+If you prefer using [prek](https://github.com/j178/prek) instead of
+pre-commit, you can define a `prek.toml` file with your hooks:
+
+```toml
+[[repos]]
+repo = "https://github.com/astral-sh/ty-pre-commit"
+rev = "v0.0.46" # ty version.
+hooks = [
+  { id = "ty" },
+]
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -1,28 +1,20 @@
 # ty-pre-commit
 
-[![image](https://img.shields.io/pypi/v/ty/0.0.46.svg)](https://pypi.python.org/pypi/ty)
-[![image](https://img.shields.io/pypi/l/ty/0.0.46.svg)](https://pypi.python.org/pypi/ty)
-[![image](https://img.shields.io/pypi/pyversions/ty/0.0.46.svg)](https://pypi.python.org/pypi/ty)
+[![ty](https://img.shields.io/endpoint?url=https://raw.githubusercontent.com/astral-sh/ty/main/assets/badge/v0.json)](https://github.com/astral-sh/ty)
+[![PyPI version](https://img.shields.io/pypi/v/ty/0.0.46.svg)](https://pypi.python.org/pypi/ty)
+[![License](https://img.shields.io/pypi/l/ty/0.0.46.svg)](https://pypi.python.org/pypi/ty)
+[![Supported Python versions](https://img.shields.io/pypi/pyversions/ty/0.0.46.svg)](https://pypi.python.org/pypi/ty)
 [![Actions status](https://github.com/astral-sh/ty-pre-commit/workflows/main/badge.svg)](https://github.com/astral-sh/ty-pre-commit/actions)
 
-A [pre-commit](https://pre-commit.com/) hook for running [ty](https://github.com/astral-sh/ty)
-quickly over your whole Python project.
+A [pre-commit](https://pre-commit.com/) hook for running [ty](https://github.com/astral-sh/ty) quickly over your whole Python project.
 
-The hook uses the dependencies declared in your project's `pyproject.toml`, so your project
-configuration remains the single source of truth: you do not need to duplicate type-checking
-dependencies in the hook's `additional_dependencies` setting. By default, uv installs the project's [`dev`
-dependency group](https://docs.astral.sh/uv/concepts/projects/dependencies/#default-groups); use
-`tool.uv.default-groups` to customize which groups are installed.
-Any dependencies listed in the hook's `additional_dependencies` setting will be ignored by ty.
+When ty is invoked by this hook, dependencies declared in your project's `pyproject.toml` will automatically be resolvable by ty. This means your project configuration remains the single source of truth: you do not need to duplicate type-checking dependencies in the hook's `additional_dependencies` setting. Any additional dependencies listed in the hook's `additional_dependencies` setting **will not be resolvable** by ty.
 
-Under the hood, the hook runs [uv](https://github.com/astral-sh/uv)'s preview
-[`uv check`](https://docs.astral.sh/uv/reference/cli/#uv-check) command. Each hook revision pins both
-the corresponding ty version and the latest uv version that was available when that ty version was
-released. New ty releases trigger ty-pre-commit releases; new uv releases do not trigger releases
-on their own. The full uv command invoked by the hook can be found in
-[`.pre-commit-hooks.yaml`](.pre-commit-hooks.yaml).
+Under the hood, the hook runs [uv](https://github.com/astral-sh/uv)'s preview [`uv check`](https://docs.astral.sh/uv/reference/cli/#uv-check) command. Each hook revision pins both the corresponding ty version and the latest uv version that was available when that ty version was released. New ty releases trigger ty-pre-commit releases; new uv releases do not trigger releases on their own. The full uv command invoked by the hook can be found in [`.pre-commit-hooks.yaml`](.pre-commit-hooks.yaml).
 
-### Using ty with pre-commit
+Configure ty in your project's `pyproject.toml` or `ty.toml`: see [ty's configuration reference](https://docs.astral.sh/ty/reference/configuration/).
+
+## Using ty with pre-commit
 
 To run ty via pre-commit, add the following to your `.pre-commit-config.yaml`:
 
@@ -35,48 +27,9 @@ repos:
     - id: ty
 ```
 
-Configure ty in your project's `pyproject.toml` or `ty.toml`; see
-[ty's configuration reference](https://docs.astral.sh/ty/reference/configuration/).
+## Using ty with prek
 
-The `ty` hook uses uv's normal project behavior. It may create or update `uv.lock`, create a local
-virtual environment if one does not exist, and sync the local virtual environment before checking
-the project.
-
-The `ty` hook accepts additional [`uv check`](https://docs.astral.sh/uv/reference/cli/#uv-check)
-arguments. If you do not want the hook to create or update your project's lockfile or local virtual
-environment, use uv's isolated mode:
-
-```yaml
-hooks:
-  - id: ty
-    args: [--isolated]
-```
-
-`--isolated` resolves and installs the project's declared requirements into a temporary virtual
-environment. It leaves the project's existing virtual environment and lockfile unchanged, and does
-not create either one if it is missing. It may still populate uv's cache or download a compatible
-Python interpreter.
-
-Other synchronization options include:
-
-- `--locked` still syncs the virtual environment, but fails if `uv.lock` is missing or out of date.
-- `--frozen` still syncs the virtual environment using `uv.lock` without checking or updating it.
-- `--no-sync` skips synchronization entirely. Use it only if another step keeps the virtual
-  environment up to date.
-
-The hook always runs and does not pass filenames to ty. ty checks the full project according to your
-ty configuration, including for deletion-only commits where no Python filename remains for
-pre-commit or prek to match.
-
-You can customize which files ty emits diagnostics for using the [`src.include` and `src.exclude` settings](https://docs.astral.sh/ty/exclusions/) in your ty configuration.
-
-Do not set `pass_filenames: true`. `uv check` does not accept positional arguments, so the hook
-errors when pre-commit or prek appends filenames to the command.
-
-### Using ty with prek
-
-If you prefer using [prek](https://github.com/j178/prek) instead of
-pre-commit, you can define a `prek.toml` file with your hooks:
+If you prefer using [prek](https://github.com/j178/prek) instead of pre-commit, you can define a `prek.toml` file with your hooks:
 
 ```toml
 [[repos]]
@@ -87,6 +40,64 @@ hooks = [
 ]
 ```
 
+## Customizing side effects of the hook
+
+By default, the `ty` hook uses uv's normal behavior with regards to locking and synchronizing projects. The hook's default behavior may therefore create or update a `uv.lock` file, create a local virtual environment if one does not exist, and/or install or update dependencies into a local virtual environment.
+
+However, the `ty` hook accepts all additional arguments accepted by [`uv check`]((https://docs.astral.sh/uv/reference/cli/#uv-check)). If you do not want the hook to create or update your project's uv lockfile or local virtual environment, use uv's isolated mode:
+
+```yaml
+hooks:
+  - id: ty
+    args: [--isolated]
+```
+
+Other options can also be used to further increase the idempotency of the hook, if desired:
+
+```yaml
+hooks:
+  - id: ty
+    args: [--isolated, --no-python-downloads, --no-cache]
+```
+
+See the [`uv check` reference documentation](https://docs.astral.sh/uv/reference/cli/#uv-check) for an exhaustive list of options available.
+
+## Customizing files checked by ty
+
+Many pre-commit hooks pass a list of all files modified in that commit to the underlying tool. This can be an effective optimization in many cases, as it can allow a hook to only perform checks on the files that changed in that commit.
+
+Unfortunately, this is not a good model for a pre-commit hook that invokes a type checker. The reason is that a commit that only changes `a.py` can easily cause new diagnostics to appear in `b.py`, even if the commit made no edits to `b.py` (`b.py` might import `a.py`!). As such, this hook does not pass filenames to ty; instead, ty checks the full project according to your ty configuration. You can customize which files ty emits diagnostics for using the [`src.include` and `src.exclude` settings](https://docs.astral.sh/ty/exclusions/) in your ty configuration.
+
+Do not try to override this behavior by setting `pass_filenames: true` in your pre-commit configuration for this hook. `uv check` does not accept positional arguments, so **the hook will error** if pre-commit or prek attempts to pass filenames to the hook.
+
+## Customizing when the hook runs
+
+By default, the hook runs on every commit. This ensures that the hook will run even on commits that only delete Python files. However, it also has the drawback that the hook will run even on commits that do not add, modify or delete any Python files. (pre-commit and prek do not provide ways of distinguishing between commits that delete Python files and commits that only delete non-Python files.)
+
+This behavior can be overridden in your pre-commit configuration by setting `always_run: false`:
+
+```yaml
+hooks:
+  - id: ty
+    always_run: false
+```
+
+## Customizing dependencies installed by the hook
+
+As well as your project's base dependencies, uv will also install any dependencies listed in your project's default [dependency groups](https://packaging.python.org/en/latest/specifications/dependency-groups/) (which includes the `dev` group). The [`tool.uv.default-groups`](https://docs.astral.sh/uv/concepts/projects/dependencies/#default-groups) `pyproject.toml` setting can be used to customize your project's default groups.
+
+The hook also accepts uv's standard CLI arguments, which can all be passed as `args` to further customize uv's behavior here. For example:
+
+```yaml
+hooks:
+  - id: ty
+    # to avoid uv installing the `dev` group,
+    # but ensure that dependencies in the `typechecking` group are installed:
+    args: [--no-default-groups, --group=typechecking]
+```
+
+See [the `uv check` reference documentation](https://docs.astral.sh/uv/reference/cli/#uv-check) for a full list of supported flags.
+
 ## License
 
 ty-pre-commit is licensed under either of
@@ -96,12 +107,10 @@ ty-pre-commit is licensed under either of
 
 at your option.
 
-Unless you explicitly state otherwise, any contribution intentionally submitted
-for inclusion in ty-pre-commit by you, as defined in the Apache-2.0 license, shall be
-dually licensed as above, without any additional terms or conditions.
+Unless you explicitly state otherwise, any contribution intentionally submitted for inclusion in ty-pre-commit by you, as defined in the Apache-2.0 license, shall be dually licensed as above, without any additional terms or conditions.
 
 <div align="center">
   <a target="_blank" href="https://astral.sh" style="background:none">
-    <img src="https://raw.githubusercontent.com/astral-sh/ty/main/assets/svg/Astral.svg">
+    <img alt="Astral" src="https://raw.githubusercontent.com/astral-sh/ruff/main/assets/svg/Astral.svg">
   </a>
 </div>

--- a/mirror.py
+++ b/mirror.py
@@ -9,65 +9,82 @@
 
 import re
 import subprocess
-import tomllib
 import typing
+from datetime import datetime
 from pathlib import Path
 
 import urllib3
-from packaging.requirements import Requirement
 from packaging.version import Version
 
 
 def main():
-    with open(Path(__file__).parent / "pyproject.toml", "rb") as f:
-        pyproject = tomllib.load(f)
+    ty_releases = get_releases(package="ty")
+    current_ty_version = get_current_ty_version()
+    target_versions = sorted(v for v in ty_releases if v > current_ty_version)
+    if not target_versions:
+        return
 
-    all_versions = get_all_versions()
-    current_version = get_current_version(pyproject=pyproject)
-    target_versions = [v for v in all_versions if v > current_version]
+    uv_releases = get_releases(package="uv")
 
-    for version in target_versions:
-        paths = process_version(version)
+    for ty_version in target_versions:
+        uv_version = get_latest_version(
+            releases=uv_releases, released_at=ty_releases[ty_version]
+        )
+        paths = process_version(ty_version=ty_version, uv_version=uv_version)
         if subprocess.check_output(["git", "status", "-s"]).strip():
             subprocess.run(["git", "add", *paths], check=True)
-            subprocess.run(["git", "commit", "-m", f"Mirror: {version}"], check=True)
-            subprocess.run(["git", "tag", f"v{version}"], check=True)
+            subprocess.run(["git", "commit", "-m", f"Mirror: {ty_version}"], check=True)
+            subprocess.run(["git", "tag", f"v{ty_version}"], check=True)
         else:
-            print(f"No change v{version}")
+            print(f"No change v{ty_version}")
 
 
-def get_all_versions() -> list[Version]:
-    response = urllib3.request("GET", "https://pypi.org/pypi/ty/json")
+def get_releases(package: str) -> dict[Version, datetime]:
+    response = urllib3.request("GET", f"https://pypi.org/pypi/{package}/json")
     if response.status != 200:
-        raise RuntimeError("Failed to fetch versions from pypi")
+        raise RuntimeError(f"Failed to fetch {package} versions from PyPI")
 
-    versions = [Version(release) for release in response.json()["releases"]]
-    return sorted(versions)
-
-
-def get_current_version(pyproject: dict) -> Version:
-    requirements = [Requirement(d) for d in pyproject["project"]["dependencies"]]
-    requirement = next((r for r in requirements if r.name == "ty"), None)
-    assert requirement is not None, "pyproject.toml does not have ty requirement"
-
-    specifiers = list(requirement.specifier)
-    assert (
-        len(specifiers) == 1 and specifiers[0].operator == "=="
-    ), f"ty's specifier should be exact matching, but `{requirement}`"
-
-    return Version(specifiers[0].version)
+    releases = {}
+    for version, files in response.json()["releases"].items():
+        if files:
+            releases[Version(version)] = min(
+                datetime.fromisoformat(file["upload_time_iso_8601"]) for file in files
+            )
+    return releases
 
 
-def process_version(version: Version) -> typing.Sequence[str]:
+def get_latest_version(
+    releases: dict[Version, datetime], released_at: datetime
+) -> Version:
+    return max(
+        version
+        for version, release_time in releases.items()
+        if release_time <= released_at
+    )
+
+
+def get_current_ty_version() -> Version:
+    content = (Path(__file__).parent / ".pre-commit-hooks.yaml").read_text()
+    versions = set(re.findall(r"--ty-version=(\S+)", content))
+    assert len(versions) == 1, ".pre-commit-hooks.yaml does not have one ty version"
+    return Version(versions.pop())
+
+
+def process_version(ty_version: Version, uv_version: Version) -> typing.Sequence[str]:
     def replace_pyproject_toml(content: str) -> str:
-        return re.sub(r'"ty==.*"', f'"ty=={version}"', content)
+        return re.sub(r'"uv==.*"', f'"uv=={uv_version}"', content)
+
+    def replace_pre_commit_hooks_yaml(content: str) -> str:
+        return re.sub(r"--ty-version=\S+", f"--ty-version={ty_version}", content)
 
     def replace_readme_md(content: str) -> str:
-        content = re.sub(r"rev: v\d+\.\d+\.\d+", f"rev: v{version}", content)
-        return re.sub(r"/ty/\d+\.\d+\.\d+\.svg", f"/ty/{version}.svg", content)
+        content = re.sub(r"rev: v\d+\.\d+\.\d+", f"rev: v{ty_version}", content)
+        content = re.sub(r'rev = "v\d+\.\d+\.\d+"', f'rev = "v{ty_version}"', content)
+        return re.sub(r"/ty/\d+\.\d+\.\d+\.svg", f"/ty/{ty_version}.svg", content)
 
     paths = {
         "pyproject.toml": replace_pyproject_toml,
+        ".pre-commit-hooks.yaml": replace_pre_commit_hooks_yaml,
         "README.md": replace_readme_md,
     }
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,5 +2,5 @@
 name = "ty-pre-commit"
 version = "0.0.0"
 dependencies = [
-    "ty==0.0.46",
+    "uv==0.11.19",
 ]


### PR DESCRIPTION
## Summary

Rework the hook and its documentation to be a wrapper around `uv check`:
- The hook now depends on uv rather than ty. The ty binary invoked by uv is downloaded by uv as part of the hook's invocation (assuming it's not cached locally by uv). The version of ty is pinned in `.pre-commit-hooks.yaml`.
- A new release of ty automatically triggers a new release of `ty-pre-commit`. `mirror.py` will update both the ty pin in `.pre-commit-hooks.yaml` and the uv pin in `pyproject.toml` to the latest available versions.
- Update the description of the hook in the README and outline how to configure uv/ty.
- ~~Switch to renovate instead of dependabot (we use it more commonly across the org) and add some basic pre-commit hooks to validate the pyproject.toml file, GitHub workflows, etc.~~

## Test Plan

I tried this out locally with and without the `--isolated` flag:


https://github.com/user-attachments/assets/7e773064-c7da-42ff-bf11-49f8108e2640


https://github.com/user-attachments/assets/f3ffa21c-3359-4cf5-a2b5-6495b8000587

