### PR TITLE
Improve pre-commit hook settings

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,10 +1,30 @@
 - id: ty
   name: ty
   description: "Run 'ty' for extremely fast Python type checking"
-  entry: ty check --ignore-active-virtual-env
+  entry: ty check
   language: python
-  types: [python]
+  types: [python, pyi]
   args: []
+
+  # Check the whole project instead of appending matching filenames to the command.
+  #
+  # Exactly which files ty should emit diagnostics on can be configured using
+  # the ty configuration file. Changes in file `b.py` can cause new diagnostics to
+  # appear in `a.py`, so passing only `b.py` as a positional argument to `ty check`
+  # if only `b.py` changed would give a false sense of security regarding whether
+  # the code still type-checks.
+  pass_filenames: false
+
+  # Run even when no files match, including deletion-only commits, since the
+  # deletion of `b.py` could cause new diagnostics in `a.py`.
+  #
+  # This setting means that the hook will run even on commits that have no Python
+  # files added/changed/deleted in them, but there's no way of "only running on
+  # Python commits" without also excluding deletion-only commits.
+  always_run: true
+
+  # Execute this hook using one process instead of pre-commit's parallel execution.
   require_serial: true
+
   additional_dependencies: []
   minimum_pre_commit_version: "2.9.2"

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,7 @@
   description: "Run 'ty' for extremely fast Python type checking"
   entry: ty check
   language: python
-  types: [python, pyi]
+  types: [python, pyi, jupyter]
   args: []
 
   # Check the whole project instead of appending matching filenames to the command.


### PR DESCRIPTION
## Summary

This makes three improvements to our pre-commit config, which I would consider blockers to being able to make this repository public:
- Setting `pass_filenames: false`. Passing positional filename arguments to `ty check` means that ty will silence diagnostics coming from any first-party files not passed on the command line. But pre-commit/prek will by default only pass the filenames that actually changed in the most recent commit. That's not a good fit for a type checker: changes in `a.py` can cause diagnostics to start appearing in an unchanged `b.py`, and you'd want to know about that. And if we switch to a `uv check`-based hook, as we intend to, `uv check` doesn't accept positional arguments on the CLI at all.
- Setting `always_run: true`. Without this, the hook won't be triggered on commits that only delete files, but again, these can cause new ty diagnostics on unchanged remaining files.
- Changing `types` to `[python, pyi]` instead of `[python]`. Since we're now setting `always_run: true`, this doesn't really do much by default, but if a user overrides `always_run` in their pre-commit configuration then we'll still run even on commits that only touch `.pyi stub files.

These changes were originally part of https://github.com/astral-sh/ty-pre-commit/pull/3, but @zsol asked for them to be pulled out into their own PR, so here is that PR!