### PR TITLE
[codex] Use types_or for hook file matching

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -3,7 +3,7 @@
   description: "Run 'ty' for extremely fast Python type checking"
   entry: uv check --quiet --preview-features=check-command --ty-version=0.0.48
   language: python
-  types: [python, pyi, jupyter]
+  types_or: [python, pyi, jupyter]
   args: []
 
   # Check the whole project instead of appending matching filenames to the command.


### PR DESCRIPTION
## Summary

- use `types_or` so Python, stub, and Jupyter files independently trigger the hook
- preserve the existing `always_run: true` default behavior

`types` combines tags with AND semantics, so overriding `always_run: false` caused the hook to skip `.py`, `.pyi`, and `.ipynb` files. `types_or` provides the intended OR semantics.

Fixes #9

## Test Plan

- reproduced `(no files to check) Skipped` against `main` with `always_run: false`
- verified the updated hook passes independently for `sample.py`, `sample.pyi`, and `sample.ipynb`
- `pre-commit validate-manifest .pre-commit-hooks.yaml`
- `git diff --check origin/main...HEAD`
