### PR TITLE
Accept the new ty tag as an optional input to `main.yml`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -3,6 +3,11 @@ on:
   schedule:
     - cron: "0 */4 * * *"
   workflow_dispatch:
+    inputs:
+      version:
+        description: ty version to mirror
+        required: false
+        type: string
 
 permissions: {}
 
@@ -26,6 +31,8 @@ jobs:
           git config user.email "$GITHUB_ACTOR@users.noreply.github.com"
 
       - run: uv run --no-project mirror.py
+        env:
+          TY_VERSION: ${{ inputs.version }}
 
       - name: check for unpushed commits
         id: check_unpushed

--- a/mirror.py
+++ b/mirror.py
@@ -7,6 +7,7 @@
 # ///
 """Update ty-pre-commit to the latest version of ty."""
 
+import os
 import re
 import subprocess
 import typing
@@ -18,18 +19,28 @@ from packaging.version import Version
 
 
 def main():
-    ty_releases = get_releases(package="ty")
     current_ty_version = get_current_ty_version()
-    target_versions = sorted(v for v in ty_releases if v > current_ty_version)
+    dispatched_version = os.environ.get("TY_VERSION")
+    if dispatched_version:
+        ty_releases = None
+        target_versions = [Version(dispatched_version)]
+    else:
+        ty_releases = get_releases(package="ty")
+        target_versions = list(ty_releases)
+
+    target_versions = sorted(v for v in target_versions if v > current_ty_version)
     if not target_versions:
         return
 
     uv_releases = get_releases(package="uv")
 
     for ty_version in target_versions:
-        uv_version = get_latest_version(
-            releases=uv_releases, released_at=ty_releases[ty_version]
-        )
+        if ty_releases is None:
+            uv_version = max(uv_releases)
+        else:
+            uv_version = get_latest_version(
+                releases=uv_releases, released_at=ty_releases[ty_version]
+            )
         paths = process_version(ty_version=ty_version, uv_version=uv_version)
         if subprocess.check_output(["git", "status", "-s"]).strip():
             subprocess.run(["git", "add", *paths], check=True)


### PR DESCRIPTION
## Summary

Yesterday's ty release successfully triggered `main.yml` in this workflow immediately after the new ty version had been pushed to PyPI, but `main.yml` in this workflow immediately exited because the new ty release was not yet available to _download_ from PyPI (a race condition), so it didn't think there were any updates to be made: https://github.com/astral-sh/ty-pre-commit/actions/runs/27310841914/job/80680351275. I had to manually rerun the workflow, after which a release of ty-pre-commit was successfully triggered: https://github.com/astral-sh/ty-pre-commit/actions/runs/27311104208/job/80681215537.

I don't know why this particular race condition affected us the first time we tried to automatically release ty-pre-commit, when it has apparently never affected ruff-pre-commit. According to codex, this is a latent bug that could also have affected ruff-pre-commit on any Ruff release, however. I'm a bit sceptical about this, but I've pushed codex quite hard on it, and it can't think of another explanation. (Neither can I.)

Regardless, this PR adds a mechanism whereby Ruff can pass a specific release tag to `main.yml`, which will then cause the workflow on this repo to wait (for up to two minutes or so) until that release is available on PyPI. This seems like reasonable hardening of the workflow, even if it's not _actually_ fixing what happened yesterday.