### PR TITLE
Document workarounds for pre-commit.ci users

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -15,6 +15,7 @@ jobs:
   build:
     name: main
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     permissions:
       contents: write
     steps:
@@ -32,6 +33,7 @@ jobs:
 
       - run: uv run --no-project mirror.py
         env:
+          GITHUB_TOKEN: ${{ github.token }}
           TY_VERSION: ${{ inputs.version }}
 
       - name: check for unpushed commits

--- a/README.md
+++ b/README.md
@@ -106,28 +106,28 @@ ty-pre-commit works well with a variety of pre-commit/prek runners in CI. For Gi
 pre-commit-action:
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout
-    - uses: actions/setup-python
-    - uses: pre-commit/action
+    - uses: actions/checkout@v6.0.3
+    - uses: actions/setup-python@v6.2.0
+    - uses: pre-commit/action@v3.0.1
 
 prek-action:
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout
-    - uses: j178/prek-action
+    - uses: actions/checkout@v6.0.3
+    - uses: j178/prek-action@v2.0.4
 
 pre-commit-standalone:
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout
-    - uses: astral-sh/setup-uv
+    - uses: actions/checkout@v6.0.3
+    - uses: astral-sh/setup-uv@v8.2.0
     - run: uvx pre-commit run --all-files
 
 prek-standalone:
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout
-    - uses: astral-sh/setup-uv
+    - uses: actions/checkout@v6.0.3
+    - uses: astral-sh/setup-uv@v8.2.0
     - run: uvx prek run --all-files
 ```
 
@@ -140,15 +140,15 @@ ci:
   skip: [ty]
 ```
 
-and then invoking ty separately in CI -- for example, in GitHub Actions:
+and then invoking ty separately in CI -- for example, in GitHub Actions, assuming you have ty pinned in your `pyproject.toml` file:
 
 ```yaml
 ty:
   runs-on: ubuntu-latest
   steps:
-    - uses: actions/checkout
-    - uses: astral-sh/setup-uv
-    - run: uv check
+    - uses: actions/checkout@v6.0.3
+    - uses: astral-sh/setup-uv@v8.2.0
+    - run: uv run ty check
 ```
 
 ## License

--- a/README.md
+++ b/README.md
@@ -98,6 +98,59 @@ hooks:
 
 See [the `uv check` reference documentation](https://docs.astral.sh/uv/reference/cli/#uv-check) for a full list of supported flags.
 
+## Running pre-commit in CI with ty-pre-commit
+
+ty-pre-commit works well with a variety of pre-commit/prek runners in CI. For GitHub Actions, any of the following example jobs should invoke the hook without issue:
+
+```yaml
+pre-commit-action:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout
+    - uses: actions/setup-python
+    - uses: pre-commit/action
+
+prek-action:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout
+    - uses: j178/prek-action
+
+pre-commit-standalone:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout
+    - uses: astral-sh/setup-uv
+    - run: uvx pre-commit run --all-files
+
+prek-standalone:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout
+    - uses: astral-sh/setup-uv
+    - run: uvx prek run --all-files
+```
+
+Any of the above can also be combined with [`pre-commit-ci-lite`](https://pre-commit.ci/lite) to enable autofixes to be pushed to PRs.
+
+Unfortunately, ty-pre-commit does not work with the [pre-commit.ci](https://pre-commit.ci/) runner. ty-pre-commit requires network access, which is [disabled](https://github.com/pre-commit-ci/issues/issues/47#issuecomment-804481763) by pre-commit.ci during invocation of hooks. If you use pre-commit.ci as your pre-commit runner in CI, we recommend adding this to your `.pre-commit-config.yaml` file:
+
+```yaml
+ci:
+  skip: [ty]
+```
+
+and then invoking ty separately in CI -- for example, in GitHub Actions:
+
+```yaml
+ty:
+  runs-on: ubuntu-latest
+  steps:
+    - uses: actions/checkout
+    - uses: astral-sh/setup-uv
+    - run: uv check
+```
+
 ## License
 
 ty-pre-commit is licensed under either of

--- a/mirror.py
+++ b/mirror.py
@@ -5,7 +5,7 @@
 #   "urllib3==2.0.5",
 # ]
 # ///
-"""Update ty-pre-commit to the latest version of ty."""
+"""Mirror ty releases and refresh the documented GitHub Action versions."""
 
 import os
 import re
@@ -16,6 +16,26 @@ from pathlib import Path
 
 import urllib3
 from packaging.version import Version
+from urllib3.util import Retry, Timeout
+
+GITHUB_ACTIONS = (
+    "actions/checkout",
+    "actions/setup-python",
+    "astral-sh/setup-uv",
+    "j178/prek-action",
+    "pre-commit/action",
+)
+GITHUB_API_TIMEOUT = Timeout(connect=5, read=10)
+# Keep optional README refreshes from delaying release-critical work indefinitely.
+GITHUB_API_RETRY = Retry(
+    total=4,
+    backoff_factor=1,
+    backoff_max=5,
+    status_forcelist=(429, 500, 502, 503, 504),
+    allowed_methods={"GET"},
+    raise_on_status=False,
+    respect_retry_after_header=False,
+)
 
 
 def main():
@@ -32,6 +52,7 @@ def main():
     if not target_versions:
         return
 
+    github_action_tags = get_latest_github_action_tags()
     uv_releases = get_releases(package="uv")
 
     for ty_version in target_versions:
@@ -41,7 +62,11 @@ def main():
             uv_version = get_latest_version(
                 releases=uv_releases, released_at=ty_releases[ty_version]
             )
-        paths = process_version(ty_version=ty_version, uv_version=uv_version)
+        paths = process_version(
+            ty_version=ty_version,
+            uv_version=uv_version,
+            github_action_tags=github_action_tags,
+        )
         if subprocess.check_output(["git", "status", "-s"]).strip():
             subprocess.run(["git", "add", *paths], check=True)
             subprocess.run(["git", "commit", "-m", f"Mirror: {ty_version}"], check=True)
@@ -64,6 +89,53 @@ def get_releases(package: str) -> dict[Version, datetime]:
     return releases
 
 
+def get_latest_github_release_tag(repository: str) -> str | None:
+    headers = {
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+    if token := os.environ.get("GITHUB_TOKEN"):
+        headers["Authorization"] = f"Bearer {token}"
+
+    try:
+        response = urllib3.request(
+            "GET",
+            f"https://api.github.com/repos/{repository}/releases/latest",
+            headers=headers,
+            retries=GITHUB_API_RETRY,
+            timeout=GITHUB_API_TIMEOUT,
+        )
+    except urllib3.exceptions.HTTPError as error:
+        print(f"Failed to fetch the latest {repository} release: {error}")
+        return None
+
+    if response.status != 200:
+        print(f"Failed to fetch the latest {repository} release")
+        return None
+
+    try:
+        payload = response.json()
+    except ValueError as error:
+        print(f"Latest {repository} release returned invalid JSON: {error}")
+        return None
+
+    tag = payload.get("tag_name") if isinstance(payload, dict) else None
+    if not isinstance(tag, str):
+        print(f"Latest {repository} release does not have a tag")
+        return None
+
+    return tag
+
+
+def get_latest_github_action_tags() -> dict[str, str]:
+    tags = {}
+    for action in GITHUB_ACTIONS:
+        tag = get_latest_github_release_tag(action)
+        if tag is not None:
+            tags[action] = tag
+    return tags
+
+
 def get_latest_version(
     releases: dict[Version, datetime], released_at: datetime
 ) -> Version:
@@ -81,7 +153,11 @@ def get_current_ty_version() -> Version:
     return Version(versions.pop())
 
 
-def process_version(ty_version: Version, uv_version: Version) -> typing.Sequence[str]:
+def process_version(
+    ty_version: Version,
+    uv_version: Version,
+    github_action_tags: typing.Mapping[str, str],
+) -> typing.Sequence[str]:
     def replace_pyproject_toml(content: str) -> str:
         return re.sub(r'"uv==.*"', f'"uv=={uv_version}"', content)
 
@@ -91,7 +167,16 @@ def process_version(ty_version: Version, uv_version: Version) -> typing.Sequence
     def replace_readme_md(content: str) -> str:
         content = re.sub(r"rev: v\d+\.\d+\.\d+", f"rev: v{ty_version}", content)
         content = re.sub(r'rev = "v\d+\.\d+\.\d+"', f'rev = "v{ty_version}"', content)
-        return re.sub(r"/ty/\d+\.\d+\.\d+\.svg", f"/ty/{ty_version}.svg", content)
+        content = re.sub(r"/ty/\d+\.\d+\.\d+\.svg", f"/ty/{ty_version}.svg", content)
+        for action, tag in github_action_tags.items():
+            content, replacements = re.subn(
+                rf"uses: {re.escape(action)}@\S+",
+                f"uses: {action}@{tag}",
+                content,
+            )
+            if replacements == 0:
+                raise RuntimeError(f"README.md does not reference {action}")
+        return content
 
     paths = {
         "pyproject.toml": replace_pyproject_toml,


### PR DESCRIPTION
## Summary

Document ways of invoking pre-commit/prek in CI that work well with ty-pre-commit. Document why ty-pre-commit cannot work with pre-commit.ci, and document workarounds for pre-commit.ci users.

Fixes #13, closes #14