### PR TITLE
Remove cron trigger for releases

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,7 +1,5 @@
 name: main
 on:
-  schedule:
-    - cron: "0 */4 * * *"
   workflow_dispatch:
     inputs:
       version:


### PR DESCRIPTION
## Summary

If a ty release succeeds in being published to PyPI but the GitHub release fails, the cron job here happily publishes a broken release of ty-pre-commit: broken because if ty==0.0.52 exists on PyPI but not on GitHub, ty-pre-commit will pin ty to a version that `uv check` cannot download when the hook is invoked, since `uv check` downloads ty from GitHub rather than from PyPI.

@zsol may change this `uv check` behaviour in the future so that uv can download ty either primarily from PyPI or from PyPI as a fallback. But for now let's just remove the cron job, since it's already resulted in two ty-pre-commit releases that were temporarily broken while we tried to fix the ty release upstream.
